### PR TITLE
**0.0.6** (2025/11/28)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 ### toT — Reading Meter ###
-**Versión:** 0.0.5 (2025/11/27)  
+**Versión:** 0.0.6 (2025/11/28)  
 
 Aplicación de escritorio (Electron) para contar palabras y caracteres, estimar tiempos de lectura, cronometrar lecturas y gestionar presets de velocidad (WPM).
 
@@ -66,7 +66,7 @@ npm start
 
 * Nuevo Menu / barra superior
 - Se habilitó la barra superior, reemplazando la barra por defecto de Electron.
-- Se crearon los botones de la barra superior:
+- Se crearon (visualmente) los botones de la barra superior:
   - ¿Cómo usar la app?
     - Guía básica 
     - Instrucciones completas
@@ -93,6 +93,7 @@ npm start
     - Actualizar a última versión
     - Readme
     - Acerca de
+
 - Código: Se habilitó un sistema de flujo para la barra superior. Por ahora sin funciones reales.
 - Flujo claro: main → preload → menu.js → renderer (acciones).
   - Lógica de ventanas de main.js:
@@ -121,6 +122,34 @@ npm start
 * Logos nuevos
   - Mejora de logo toT
   - Inserción de logo Cibersin
+
+**0.0.6** (2025/11/28)
+
+* Menú
+
+- Habilitados funcionalmente botones del menú / barra superior:
+
+  - Informativos: Guía básica, Instrucciones completas, FAQ, Readme y Acerca de.
+    - Todos usan un infomodal compartido que carga su HTML correspondiente.
+    - Si no se encuentra el HTML, muestra un aviso: "No hay contenido disponible para ...".
+    - Archivos agregados: guia_basica.html, instrucciones.html, faq.html, readme.html, acerca_de.html
+    
+    NOTAS: 
+    - Por el momento HMLS solo tienen un texto de prueba.
+      - Al editarlos hay que verificar que ningún HTML dentro de public/info/ incluya scripts inline para cumplir CSP, aunque con el setup actual no genera problemas.
+
+    - Botón Presets por defecto.
+      - Abre la carpeta config/presets_defaults en el explorador del sistema operativo.
+        - El usuario puede modificar o eliminar los archivos .json con seguridad, sin romper la app.
+          - Si modifica un archivo, al próximo arranque la app considerará nuevos presets por defecto para las operaciones normales en la ventana principal. (Ejemplo: Al presionar el botón "R" en la sección de Selector de velocidad de lectura, se restauran los presets por defecto según los archivos de esa carpeta, modificados o no).
+          - Si el usuario elimina un archivo desde la carpeta (no desde la ventana principal), al próximo arranque la app restaurará el archivo de instalación.
+
+Nota técnica:
+- Usamos shell.openPath(...) (expuesto por shell en electron) para abrir la carpeta en el explorador nativo. En entornos empaquetados (asar), shell.openPath funciona si la ruta apuntada está fuera del asar (la carpeta config/ está fuera), por lo que no debería presentar problemas.
+
+* Modificaciones menores de diseño para ajustar el layout.
+
+* El preset default general cambió su wpm de 240 a 250 y tiene nueva descripción.
 
 ## Autor y Créditos ##
 

--- a/ToDo.txt
+++ b/ToDo.txt
@@ -1,25 +1,41 @@
 ### TO DO Y PLAN GENERAL ###
 
-Pendientes varios:
-- Limitar current text
-
 # ÍTEM ACTUAL #
 
-* Barra superior de pantalla principal *
+* Revisar límite de caracteres del current text *
 
-LISTO:
-- Modal html funcional para: guía básica, instrucciones, faq, readme y acerca de.
-- Botón Presets por defecto (abre carpeta presets)
-
-FALTA:
-- Modificar htmls de los botones con información: guía básica, instrucciones, faq, readme y acerca de.
-- NOTA: Verificar que ningún HTML dentro de public/info/ incluya scripts inline para cumplir CSP, aunque con el setup actual no genera problemas.
-
-Resto del menú quedaría pendiente para más adelante
+* Calculos *
+- ¡Advertencia sobre el método de conteo de palabras!
+- Analizar nuevos métodos de conteo, más precisos
 
 # Más adelante #
 
-* Revisar limite de palabras del texto vigente *
+* Ventana flotante *
+- Activar y desactivar desde el cronómetro con el botón "VF".
+
+* Revisión y depuración del código*
+
+* Internacionalización *
+- Archivos de 18i.
+
+* Otros *
+- Agregar soporte multilenguaje
+- Implementar semiauto-update
+- Construir versión portable
+- Short-cuts
+
+* Nuevas funciones *
+- Test de lectura
+- Calculador de palabras en archivos de texto
+- Calculador de palabras insertas en imágenes
+  - Averiguar sistema OCR como extractor de palabras en imágenes.
+
+* Estilos/skins *
+
+* Mejorar Readme * 
+
+* Revisar seguridad de la aplicación y legalidad *
+ - Licencia de la fuente kremlin duma para logo Cibersin
 
 * Habilitar botones faltantes del menú *
 
@@ -44,35 +60,11 @@ Resto del menú quedaría pendiente para más adelante
 - ?
   - Actualizar a última versión
 
+* Actualización de botones informativos del menú *
+- Modificar htmls de los botones con información: guía básica, instrucciones, faq, readme y acerca de.
+  - NOTA: Verificar que ningún HTML dentro de public/info/ incluya scripts inline para cumplir CSP, aunque con el setup actual no genera problemas.
+
 * Revisión y depuración del código*
-
-* Calculos *
-- ¡Advertencia sobre el método de conteo de palabras!
-- Analizar nuevos métodos de conteo, más precisos
-- Averiguar sistema OCR como extractor de palabras en imaganes.
-
-* Ventana flotante *
-- Activar y desactivar desde el cronómetro con el botón "VF".
-
-* Internacionalización *
-- Archivos de 18i.
-
-* Otros *
-- Agregar soporte multilenguaje
-- Implementar semiauto-update
-- Construir versión portable
-- Short-cuts
-
-* Nuevas funciones *
-- Test de lectura
-- Calculador de palabras insertas en imágenes
-
-* Estilos/skins *
-
-* Mejorar Readme * 
-
-* Revisar seguridad de la aplicación y legalidad *
- - Licencia de la fuente kremlin duma para logo Cibersin
 
 * Empaquetado multiplataforma (Windows, macOS y Linux) *
 - Empaquetado para Windows, versión de prueba *

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "toT — Reading Meter",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "description": "Contador y estimador de tiempo de lectura",
   "main": "electron/main.js",
   "scripts": {


### PR DESCRIPTION
* Menú

- Habilitados funcionalmente botones del menú / barra superior:

  - Informativos: Guía básica, Instrucciones completas, FAQ, Readme y Acerca de.
    - Todos usan un infomodal compartido que carga su HTML correspondiente.
    - Si no se encuentra el HTML, muestra un aviso: "No hay contenido disponible para ...".
    - Archivos agregados: guia_basica.html, instrucciones.html, faq.html, readme.html, acerca_de.html

    NOTAS:
    - Por el momento HMLS solo tienen un texto de prueba.
      - Al editarlos hay que verificar que ningún HTML dentro de public/info/ incluya scripts inline para cumplir CSP, aunque con el setup actual no genera problemas.

    - Botón Presets por defecto. - Abre la carpeta config/presets_defaults en el explorador del sistema operativo.
        - El usuario puede modificar o eliminar los archivos .json con seguridad, sin romper la app. - Si modifica un archivo, al próximo arranque la app considerará nuevos presets por defecto para las operaciones normales en la ventana principal. (Ejemplo: Al presionar el botón "R" en la sección de Selector de velocidad de lectura, se restauran los presets por defecto según los archivos de esa carpeta, modificados o no). - Si el usuario elimina un archivo desde la carpeta (no desde la ventana principal), al próximo arranque la app restaurará el archivo de instalación.

Nota técnica:
- Usamos shell.openPath(...) (expuesto por shell en electron) para abrir la carpeta en el explorador nativo. En entornos empaquetados (asar), shell.openPath funciona si la ruta apuntada está fuera del asar (la carpeta config/ está fuera), por lo que no debería presentar problemas.

* Modificaciones menores de diseño para ajustar el layout.

* El preset default general cambió su wpm de 240 a 250 y tiene nueva descripción.